### PR TITLE
Add timeline slider for historical borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,10 +119,28 @@
 		background-color: #f0f0f0;
 	}
 		
-		#bordersElement {
-		position: absolute;
-		z-index: 10; /* Assurez-vous que la carte a un z-index inférieur */
-	}
+        #bordersElement {
+                position: absolute;
+                z-index: 10; /* Assurez-vous que la carte a un z-index inférieur */
+        }
+
+        /* Timeline container at bottom */
+        #timelineContainer {
+                position: fixed;
+                bottom: 10px;
+                left: 50%;
+                transform: translateX(-50%);
+                background-color: rgba(255,255,255,0.8);
+                padding: 10px;
+                border-radius: 5px;
+                z-index: 1002;
+                font-family: 'Verdana', sans-serif;
+                text-align: center;
+        }
+
+        #timeline {
+                width: 80%;
+        }
     </style>
 </head>
 
@@ -151,6 +169,12 @@
     </div>
 </div>
 
+<!-- Timeline Slider for Historical Borders -->
+<div id="timelineContainer">
+    <input type="range" id="timeline" min="0" max="2" value="0" step="1">
+    <span id="timelineLabel"></span>
+</div>
+
 
 <script type="text/javascript">
     var viewer = OpenSeadragon({
@@ -174,10 +198,35 @@
 
     // Exemple de polygone de frontière
     var sampleBorder = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-    sampleBorder.setAttribute('points', '0.2,0.2 0.3,0.2 0.3,0.3 0.2,0.3');
+    sampleBorder.setAttribute('points', '0.45,0.45 0.55,0.45 0.55,0.55 0.45,0.55');
     sampleBorder.setAttribute('stroke', 'red');
     sampleBorder.setAttribute('fill', 'transparent');
     bordersLayer.appendChild(sampleBorder);
+
+    // Formes de frontière selon la période historique
+    var borderShapes = {
+        0: '0.45,0.45 0.55,0.45 0.55,0.55 0.45,0.55',
+        1: '0.40,0.45 0.60,0.45 0.60,0.55 0.40,0.55',
+        2: '0.40,0.40 0.60,0.40 0.60,0.60 0.40,0.60'
+    };
+
+    var timelineYears = ['1000', '1500', '2000'];
+
+    var timeline = document.getElementById('timeline');
+    var timelineLabel = document.getElementById('timelineLabel');
+
+    function updateBorders() {
+        var val = parseInt(timeline.value, 10);
+        var points = borderShapes[val];
+        if (points) {
+            sampleBorder.setAttribute('points', points);
+        }
+        timelineLabel.textContent = timelineYears[val];
+    }
+
+    // Initial display
+    updateBorders();
+    timeline.addEventListener('input', updateBorders);
 
     sampleBorder.addEventListener('mouseover', function() {
         sampleBorder.setAttribute('fill', 'rgba(255,0,0,0.3)');


### PR DESCRIPTION
## Summary
- add timeline slider at the bottom of the page
- style timeline container
- center the example border polygon
- change polygon depending on the selected period

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e7912c6ec832db34e58adc92a2318