### PR TITLE
Add basic measurement tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Simply open `index.html` in a modern web browser. The page loads the map tiles f
 ## Dependencies
 
 The only JavaScript dependency bundled in the repository is OpenSeadragon, which provides zooming and panning functionality. All geographic labels are defined in the CSV files under `Data`.
+
+## Mesures sur la carte
+
+Deux outils permettent maintenant de mesurer des distances et des surfaces directement sur la carte. La largeur totale du monde est estimée à environ 1000 km. Utilisez les boutons *Mesurer distance* et *Mesurer surface* pour tracer respectivement une ligne ou un polygone et obtenir la valeur correspondante en kilomètres ou kilomètres carrés.

--- a/index.html
+++ b/index.html
@@ -153,6 +153,8 @@
             <button id="searchButton">Rechercher</button>
             <button id="toggleText">Afficher/Masquer textes</button>
             <button id="toggleBorders">Afficher les frontières</button>
+            <button id="measureDistance">Mesurer distance</button>
+            <button id="measureArea">Mesurer surface</button>
         </div>
 
     <!-- Fenêtre d'information pour afficher les détails de la ville -->
@@ -534,6 +536,105 @@
             bordersLayer.style.display = 'block';
         } else {
             bordersLayer.style.display = 'none';
+        }
+    });
+
+    // ----------- Mesure de distances et de surfaces -----------
+    var worldWidthKm = 1000; // Largeur approximative du monde en kilomètres
+    var measureMode = null; // 'distance' ou 'area'
+    var measurePoints = [];
+    var measureLayer = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    measureLayer.setAttribute('id', 'measureLayer');
+    svgOverlay.node().appendChild(measureLayer);
+
+    function resetMeasure() {
+        measurePoints = [];
+        while (measureLayer.firstChild) {
+            measureLayer.removeChild(measureLayer.firstChild);
+        }
+    }
+
+    function clearLayer() {
+        while (measureLayer.firstChild) {
+            measureLayer.removeChild(measureLayer.firstChild);
+        }
+    }
+
+    function distanceKm(p1, p2) {
+        var dx = (p2.x - p1.x) * worldWidthKm;
+        var dy = (p2.y - p1.y) * worldWidthKm;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    function polygonArea(points) {
+        var area = 0;
+        for (var i = 0, j = points.length - 1; i < points.length; j = i++) {
+            area += (points[j].x * points[i].y) - (points[i].x * points[j].y);
+        }
+        area = Math.abs(area / 2);
+        return area * worldWidthKm * worldWidthKm;
+    }
+
+    function showLabel(text, coord) {
+        var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        label.setAttribute("x", coord.x);
+        label.setAttribute("y", coord.y);
+        label.setAttribute("fill", "yellow");
+        label.setAttribute("font-size", "0.02");
+        label.setAttribute("font-family", "Verdana, sans-serif");
+        label.setAttribute("pointer-events", "none");
+        label.textContent = text;
+        measureLayer.appendChild(label);
+    }
+
+    document.getElementById('measureDistance').addEventListener('click', function() {
+        measureMode = 'distance';
+        resetMeasure();
+    });
+
+    document.getElementById('measureArea').addEventListener('click', function() {
+        measureMode = 'area';
+        resetMeasure();
+    });
+
+    viewer.addHandler('canvas-click', function(event) {
+        if (!measureMode) return;
+        var webPoint = event.position;
+        var point = viewer.viewport.pointFromPixel(webPoint);
+        measurePoints.push(point);
+
+        if (measureMode === 'distance' && measurePoints.length === 2) {
+            var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+            line.setAttribute('x1', measurePoints[0].x);
+            line.setAttribute('y1', measurePoints[0].y);
+            line.setAttribute('x2', measurePoints[1].x);
+            line.setAttribute('y2', measurePoints[1].y);
+            line.setAttribute('stroke', 'yellow');
+            line.setAttribute('stroke-width', '0.005');
+            measureLayer.appendChild(line);
+
+            var dist = distanceKm(measurePoints[0], measurePoints[1]);
+            showLabel(dist.toFixed(2) + ' km', {
+                x: (measurePoints[0].x + measurePoints[1].x) / 2,
+                y: (measurePoints[0].y + measurePoints[1].y) / 2
+            });
+            measureMode = null;
+        } else if (measureMode === 'area') {
+            var poly = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+            poly.setAttribute('points', measurePoints.map(function(p){ return p.x + ',' + p.y; }).join(' '));
+            poly.setAttribute('stroke', 'yellow');
+            poly.setAttribute('fill', 'rgba(255,255,0,0.3)');
+            poly.setAttribute('stroke-width', '0.003');
+            clearLayer();
+            measureLayer.appendChild(poly);
+        }
+    });
+
+    viewer.addHandler('canvas-double-click', function() {
+        if (measureMode === 'area' && measurePoints.length > 2) {
+            var area = polygonArea(measurePoints);
+            showLabel(area.toFixed(2) + ' km²', measurePoints[0]);
+            measureMode = null;
         }
     });
 


### PR DESCRIPTION
## Summary
- add distance and area measurement buttons in the controls panel
- implement simple tools using OpenSeadragon overlay to draw lines or polygons
- update documentation with usage notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687763f323f0832d876a23a082a7a44f